### PR TITLE
guardrails: more flexible and configurable system

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
+	"strings"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/charmitro/ai_proxy/internal/config"
 	"github.com/charmitro/ai_proxy/internal/guardrails"
 	"github.com/charmitro/ai_proxy/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // MockLLMClient implements the llm.Client interface for testing
@@ -23,7 +25,7 @@ func (m *MockLLMClient) Query(prompt string, modelParams map[string]interface{})
 // testMetrics creates metrics with a test registry to avoid conflicts
 func testMetrics() *metrics.Metrics {
 	reg := prometheus.NewRegistry()
-	
+
 	m := &metrics.Metrics{
 		LLMRequestsTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "test_llm_requests_total",
@@ -42,20 +44,194 @@ func testMetrics() *metrics.Metrics {
 			Help: "Total number of requests blocked by guardrails",
 		}),
 	}
-	
+
 	reg.MustRegister(m.LLMRequestsTotal)
 	reg.MustRegister(m.LLMErrorsTotal)
 	reg.MustRegister(m.LLMTokensTotal)
 	reg.MustRegister(m.GuardrailBlocksTotal)
-	
+
 	return m
+}
+
+func TestCustomRuleTypeHandling(t *testing.T) {
+	// Test handling of different numeric types in custom rule parameters and
+	// validation of pattern parameter for contains_pattern rule
+
+	// Part 1: Test word_count rule with different numeric types
+	wordCountTestCases := []struct {
+		name        string
+		maxWords    interface{}
+		content     string
+		shouldBlock bool
+	}{
+		{
+			name:        "int value",
+			maxWords:    5,
+			content:     "This has six words in it",
+			shouldBlock: true,
+		},
+		{
+			name:        "float64 value",
+			maxWords:    5.0,
+			content:     "This has six words in it",
+			shouldBlock: true,
+		},
+		{
+			name:        "int64 value",
+			maxWords:    int64(5),
+			content:     "This has six words in it",
+			shouldBlock: true,
+		},
+		{
+			name:        "float32 value",
+			maxWords:    float32(5.0),
+			content:     "This has six words in it",
+			shouldBlock: true,
+		},
+		{
+			name:        "content under limit",
+			maxWords:    10,
+			content:     "Only five words here",
+			shouldBlock: false,
+		},
+	}
+
+	for _, tc := range wordCountTestCases {
+		t.Run("WordCount_"+tc.name, func(t *testing.T) {
+			// Setup rule and parameters
+			parameters := map[string]interface{}{"max_words": tc.maxWords}
+
+			// Extract the maxWords with type switch
+			var maxWords int
+			switch v := parameters["max_words"].(type) {
+			case float64:
+				maxWords = int(v)
+			case int:
+				maxWords = v
+			case int64:
+				maxWords = int(v)
+			case float32:
+				maxWords = int(v)
+			default:
+				t.Fatalf("Unsupported type for maxWords: %T", parameters["max_words"])
+			}
+
+			// Create rule function
+			wordCountRule := func(content string) (bool, string) {
+				words := strings.Fields(content)
+				if len(words) > maxWords {
+					return true, "too many words"
+				}
+				return false, ""
+			}
+
+			// Create guardrail
+			grd := guardrails.NewCustomRuleGuardrail(
+				[]guardrails.CustomRuleFunc{wordCountRule},
+				[]string{"test word count rule"},
+			)
+
+			// Run check
+			err := grd.Check(tc.content)
+
+			// Verify result
+			if (err != nil) != tc.shouldBlock {
+				t.Errorf("Expected shouldBlock=%v, got err=%v", tc.shouldBlock, err)
+			}
+		})
+	}
+
+	// Part 2: Test contains_pattern rule with different parameter types
+	patternTestCases := []struct {
+		name        string
+		pattern     interface{}
+		content     string
+		shouldParse bool
+		shouldBlock bool
+	}{
+		{
+			name:        "valid string pattern",
+			pattern:     "test|pattern",
+			content:     "this contains test word",
+			shouldParse: true,
+			shouldBlock: true,
+		},
+		{
+			name:        "valid regex pattern",
+			pattern:     "\\d{3}-\\d{2}-\\d{4}",
+			content:     "SSN: 123-45-6789",
+			shouldParse: true,
+			shouldBlock: true,
+		},
+		{
+			name:        "no match in content",
+			pattern:     "nomatch",
+			content:     "this doesn't contain the word",
+			shouldParse: true,
+			shouldBlock: false,
+		},
+		{
+			name:        "invalid pattern type",
+			pattern:     123,
+			content:     "any content",
+			shouldParse: false,
+			shouldBlock: false,
+		},
+	}
+
+	for _, tc := range patternTestCases {
+		t.Run("Pattern_"+tc.name, func(t *testing.T) {
+			// Setup rule and parameters
+			parameters := map[string]interface{}{"pattern": tc.pattern}
+
+			// Extract and validate pattern parameter
+			patternParam := parameters["pattern"]
+			pattern, ok := patternParam.(string)
+
+			// Check if pattern parsing worked as expected
+			if ok != tc.shouldParse {
+				t.Fatalf("Expected pattern parsing=%v, got=%v", tc.shouldParse, ok)
+			}
+
+			// Skip rest of test if pattern parsing failed
+			if !ok {
+				return
+			}
+
+			// Create pattern rule function
+			patternRule := func(content string) (bool, string) {
+				matched, err := regexp.MatchString(pattern, content)
+				if err != nil {
+					return false, ""
+				}
+				if matched {
+					return true, "pattern matched"
+				}
+				return false, ""
+			}
+
+			// Create guardrail
+			grd := guardrails.NewCustomRuleGuardrail(
+				[]guardrails.CustomRuleFunc{patternRule},
+				[]string{"test pattern rule"},
+			)
+
+			// Run check
+			err := grd.Check(tc.content)
+
+			// Verify result
+			if (err != nil) != tc.shouldBlock {
+				t.Errorf("Expected shouldBlock=%v, got err=%v", tc.shouldBlock, err)
+			}
+		})
+	}
 }
 
 func TestSetupRouter(t *testing.T) {
 	// Create test configuration
 	cfg := &config.Config{
-		Server:    config.ServerConfig{Port: 8080},
-		LLM:       config.LLMConfig{URL: "https://test-url", APIKey: "test-key"},
+		Server:     config.ServerConfig{Port: 8080},
+		LLM:        config.LLMConfig{URL: "https://test-url", APIKey: "test-key"},
 		Guardrails: config.GuardrailsConfig{BannedWords: []string{"test-banned-word"}},
 	}
 
@@ -97,7 +273,7 @@ func TestSetupRouter(t *testing.T) {
 			t.Errorf("Expected status 200, got %d", w.Code)
 		}
 	})
-	
+
 	// Test query endpoint
 	t.Run("Query endpoint", func(t *testing.T) {
 		// Valid query
@@ -107,49 +283,49 @@ func TestSetupRouter(t *testing.T) {
 				"temperature": 0.7,
 			},
 		})
-		
+
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("POST", "/v1/query", bytes.NewBuffer(requestBody))
 		req.Header.Set("Content-Type", "application/json")
 		router.ServeHTTP(w, req)
-		
+
 		if w.Code != http.StatusOK {
 			t.Errorf("Expected status 200, got %d", w.Code)
 		}
-		
+
 		var response queryResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 			t.Fatalf("Failed to parse response: %v", err)
 		}
-		
+
 		if response.Completion != "Mock response for tests" {
 			t.Errorf("Expected 'Mock response for tests', got '%s'", response.Completion)
 		}
 	})
-	
+
 	// Test guardrail blocking
 	t.Run("Guardrail blocking", func(t *testing.T) {
 		requestBody, _ := json.Marshal(map[string]interface{}{
-			"prompt": "test-banned-word should be blocked",
+			"prompt":       "test-banned-word should be blocked",
 			"model_params": map[string]interface{}{},
 		})
-		
+
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("POST", "/v1/query", bytes.NewBuffer(requestBody))
 		req.Header.Set("Content-Type", "application/json")
 		router.ServeHTTP(w, req)
-		
+
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("Expected status 400, got %d", w.Code)
 		}
-		
+
 		var response map[string]string
 		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 			t.Fatalf("Failed to parse response: %v", err)
 		}
-		
+
 		if _, exists := response["error"]; !exists {
 			t.Error("Expected error in response, got none")
 		}
 	})
-} 
+}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,31 @@ llm:
   api_key: "YOUR_OPENAI_API_KEY"
 
 guardrails:
+  # Basic banned words filtering
   banned_words:
     - "bomb"
-    - "attack" 
+    - "attack"
+    - "weapon"
+    - "terrorist"
+  
+  # Regex pattern filtering for sensitive information
+  regex_patterns:
+    - "\\b\\d{3}-\\d{2}-\\d{4}\\b"  # US Social Security Numbers
+    - "\\b\\d{16}\\b"             # Credit card numbers (simplified)
+    - "\\b(?:[0-9A-Fa-f]{2}[:-]){5}(?:[0-9A-Fa-f]{2})\\b"  # MAC addresses
+  
+  # Length limitations
+  max_content_length: 10000
+  max_prompt_length: 4000
+  
+  # Custom rules with configuration
+  custom_rules:
+    - name: "Max Words"
+      type: "word_count"
+      parameters:
+        max_words: 1000
+    
+    - name: "PII Detection" 
+      type: "contains_pattern"
+      parameters:
+        pattern: "(passport|ssn|social security|credit card)"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,18 @@ type LLMConfig struct {
 
 // GuardrailsConfig contains guardrails-related configuration
 type GuardrailsConfig struct {
-	BannedWords []string `yaml:"banned_words"`
+	BannedWords      []string     `yaml:"banned_words"`
+	RegexPatterns    []string     `yaml:"regex_patterns"`
+	CustomRules      []RuleConfig `yaml:"custom_rules"`
+	MaxContentLength int          `yaml:"max_content_length"`
+	MaxPromptLength  int          `yaml:"max_prompt_length"`
+}
+
+// RuleConfig defines a custom rule configuration
+type RuleConfig struct {
+	Name       string                 `yaml:"name"`
+	Type       string                 `yaml:"type"`
+	Parameters map[string]interface{} `yaml:"parameters"`
 }
 
 // LoadConfig loads the configuration from a file or environment variables
@@ -43,7 +54,11 @@ func LoadConfig(configPath string) (*Config, error) {
 			URL: "https://api.openai.com/v1/chat/completions",
 		},
 		Guardrails: GuardrailsConfig{
-			BannedWords: []string{},
+			BannedWords:      []string{},
+			RegexPatterns:    []string{},
+			CustomRules:      []RuleConfig{},
+			MaxContentLength: 10000, // Default maximum content length
+			MaxPromptLength:  4000,  // Default maximum prompt length
 		},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,26 +11,46 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
-	
+
 	// Check server config
 	if cfg.Server.Port != 8080 {
 		t.Errorf("Expected port 8080, got %d", cfg.Server.Port)
 	}
-	
+
 	// Check LLM config
 	if cfg.LLM.URL != "https://api.openai.com/v1/chat/completions" {
 		t.Errorf("Expected OpenAI URL, got %s", cfg.LLM.URL)
 	}
-	
+
 	if cfg.LLM.APIKey != "test-api-key" {
 		t.Errorf("Expected test API key, got %s", cfg.LLM.APIKey)
 	}
-	
+
 	// Check guardrails config
 	if len(cfg.Guardrails.BannedWords) != 2 {
 		t.Errorf("Expected 2 banned words, got %d", len(cfg.Guardrails.BannedWords))
 	}
-	
+
+	if len(cfg.Guardrails.RegexPatterns) != 1 {
+		t.Errorf("Expected 1 regex pattern, got %d", len(cfg.Guardrails.RegexPatterns))
+	}
+
+	if cfg.Guardrails.MaxContentLength != 8000 {
+		t.Errorf("Expected max content length 8000, got %d", cfg.Guardrails.MaxContentLength)
+	}
+
+	if cfg.Guardrails.MaxPromptLength != 2000 {
+		t.Errorf("Expected max prompt length 2000, got %d", cfg.Guardrails.MaxPromptLength)
+	}
+
+	if len(cfg.Guardrails.CustomRules) != 1 {
+		t.Errorf("Expected 1 custom rule, got %d", len(cfg.Guardrails.CustomRules))
+	}
+
+	if cfg.Guardrails.CustomRules[0].Name != "Test Rule" {
+		t.Errorf("Expected custom rule name 'Test Rule', got %s", cfg.Guardrails.CustomRules[0].Name)
+	}
+
 	// Test env var override
 	os.Setenv("SERVER_PORT", "9090")
 	os.Setenv("LLM_API_KEY", "env-api-key")
@@ -40,21 +60,21 @@ func TestLoadConfig(t *testing.T) {
 		os.Unsetenv("LLM_API_KEY")
 		os.Unsetenv("BANNED_WORDS")
 	}()
-	
+
 	cfg, err = LoadConfig("testdata/config.yaml")
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
-	
+
 	// Check overridden values
 	if cfg.Server.Port != 9090 {
 		t.Errorf("Expected port 9090 from env, got %d", cfg.Server.Port)
 	}
-	
+
 	if cfg.LLM.APIKey != "env-api-key" {
 		t.Errorf("Expected env API key, got %s", cfg.LLM.APIKey)
 	}
-	
+
 	if len(cfg.Guardrails.BannedWords) != 3 {
 		t.Errorf("Expected 3 banned words from env, got %d", len(cfg.Guardrails.BannedWords))
 	}
@@ -66,17 +86,33 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to load config with defaults: %v", err)
 	}
-	
+
 	// Check default values
 	if cfg.Server.Port != 8080 {
 		t.Errorf("Expected default port 8080, got %d", cfg.Server.Port)
 	}
-	
+
 	if cfg.LLM.URL != "https://api.openai.com/v1/chat/completions" {
 		t.Errorf("Expected default OpenAI URL, got %s", cfg.LLM.URL)
 	}
-	
+
 	if len(cfg.Guardrails.BannedWords) != 0 {
 		t.Errorf("Expected empty banned words list by default, got %d items", len(cfg.Guardrails.BannedWords))
+	}
+
+	if len(cfg.Guardrails.RegexPatterns) != 0 {
+		t.Errorf("Expected empty regex patterns list by default, got %d items", len(cfg.Guardrails.RegexPatterns))
+	}
+
+	if cfg.Guardrails.MaxContentLength != 10000 {
+		t.Errorf("Expected default max content length 10000, got %d", cfg.Guardrails.MaxContentLength)
+	}
+
+	if cfg.Guardrails.MaxPromptLength != 4000 {
+		t.Errorf("Expected default max prompt length 4000, got %d", cfg.Guardrails.MaxPromptLength)
+	}
+
+	if len(cfg.Guardrails.CustomRules) != 0 {
+		t.Errorf("Expected empty custom rules list by default, got %d items", len(cfg.Guardrails.CustomRules))
 	}
 }

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -8,4 +8,16 @@ llm:
 guardrails:
   banned_words:
     - "bomb"
-    - "attack" 
+    - "attack"
+  
+  regex_patterns:
+    - "\\b\\d{3}-\\d{2}-\\d{4}\\b"  # SSN
+  
+  max_content_length: 8000
+  max_prompt_length: 2000
+  
+  custom_rules:
+    - name: "Test Rule"
+      type: "word_count"
+      parameters:
+        max_words: 500

--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -2,6 +2,7 @@ package guardrails
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -35,6 +36,102 @@ func (g *BannedWordsGuardrail) Check(content string) error {
 	for _, word := range g.BannedWords {
 		if strings.Contains(content, word) {
 			return fmt.Errorf("content contains banned word: %s", word)
+		}
+	}
+
+	return nil
+}
+
+// RegexGuardrail checks if content matches regex patterns
+type RegexGuardrail struct {
+	Patterns []*regexp.Regexp
+	Names    []string
+}
+
+// NewRegexGuardrail creates a new RegexGuardrail
+func NewRegexGuardrail(patterns []string) (*RegexGuardrail, error) {
+	compiledPatterns := make([]*regexp.Regexp, 0, len(patterns))
+	patternNames := make([]string, 0, len(patterns))
+
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex pattern '%s': %v", pattern, err)
+		}
+		compiledPatterns = append(compiledPatterns, re)
+		patternNames = append(patternNames, pattern)
+	}
+
+	return &RegexGuardrail{
+		Patterns: compiledPatterns,
+		Names:    patternNames,
+	}, nil
+}
+
+// Check checks if the content matches any regex patterns
+func (g *RegexGuardrail) Check(content string) error {
+	for i, pattern := range g.Patterns {
+		if pattern.MatchString(content) {
+			return fmt.Errorf("content matches forbidden pattern: %s", g.Names[i])
+		}
+	}
+
+	return nil
+}
+
+// CustomRuleFunc is a function that checks content against a custom rule
+type CustomRuleFunc func(content string) (bool, string)
+
+// CustomRuleGuardrail applies user-defined custom rules to content
+type CustomRuleGuardrail struct {
+	Rules []CustomRuleFunc
+	Names []string
+}
+
+// NewCustomRuleGuardrail creates a new CustomRuleGuardrail
+func NewCustomRuleGuardrail(rules []CustomRuleFunc, names []string) *CustomRuleGuardrail {
+	return &CustomRuleGuardrail{
+		Rules: rules,
+		Names: names,
+	}
+}
+
+// Check checks if the content violates any custom rules
+func (g *CustomRuleGuardrail) Check(content string) error {
+	for i, rule := range g.Rules {
+		if matched, details := rule(content); matched {
+			name := "custom rule"
+			if i < len(g.Names) {
+				name = g.Names[i]
+			}
+
+			if details != "" {
+				return fmt.Errorf("content blocked by %s: %s", name, details)
+			}
+			return fmt.Errorf("content blocked by %s", name)
+		}
+	}
+
+	return nil
+}
+
+// CompositeGuardrail applies multiple guardrails in sequence
+type CompositeGuardrail struct {
+	Guardrails []Guardrail
+}
+
+// NewCompositeGuardrail creates a new CompositeGuardrail
+func NewCompositeGuardrail(guardrails ...Guardrail) *CompositeGuardrail {
+	return &CompositeGuardrail{
+		Guardrails: guardrails,
+	}
+}
+
+// Check applies all guardrails in sequence
+func (g *CompositeGuardrail) Check(content string) error {
+	for _, guardrail := range g.Guardrails {
+		if err := guardrail.Check(content); err != nil {
+			return err
 		}
 	}
 

--- a/internal/guardrails/guardrails_test.go
+++ b/internal/guardrails/guardrails_test.go
@@ -1,6 +1,8 @@
 package guardrails
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -55,6 +57,259 @@ func TestBannedWordsGuardrail(t *testing.T) {
 			err := g.Check(tt.content)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BannedWordsGuardrail.Check() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRegexGuardrail(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		patterns []string
+		wantErr  bool
+	}{
+		{
+			name:     "no matches",
+			content:  "This is a safe text",
+			patterns: []string{`bomb`, `attack`},
+			wantErr:  false,
+		},
+		{
+			name:     "matches pattern",
+			content:  "How to make a bomb",
+			patterns: []string{`bomb`, `attack`},
+			wantErr:  true,
+		},
+		{
+			name:     "matches complex pattern",
+			content:  "My SSN is 123-45-6789",
+			patterns: []string{`\d{3}-\d{2}-\d{4}`},
+			wantErr:  true,
+		},
+		{
+			name:     "matches email pattern",
+			content:  "My email is test@example.com",
+			patterns: []string{`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`},
+			wantErr:  true,
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			patterns: []string{`bomb`, `attack`},
+			wantErr:  false,
+		},
+		{
+			name:     "empty patterns list",
+			content:  "Any content is safe",
+			patterns: []string{},
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, err := NewRegexGuardrail(tt.patterns)
+			if err != nil {
+				t.Fatalf("Failed to create RegexGuardrail: %v", err)
+			}
+
+			err = g.Check(tt.content)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RegexGuardrail.Check() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
+	// Test invalid regex
+	_, err := NewRegexGuardrail([]string{`[`})
+	if err == nil {
+		t.Errorf("NewRegexGuardrail() with invalid regex should return error")
+	}
+}
+
+func TestCustomRuleGuardrail(t *testing.T) {
+	// Example custom rules
+	maxLengthRule := func(maxLen int) CustomRuleFunc {
+		return func(content string) (bool, string) {
+			if len(content) > maxLen {
+				return true, "content too long"
+			}
+			return false, ""
+		}
+	}
+
+	profanityRule := func(profanities []string) CustomRuleFunc {
+		return func(content string) (bool, string) {
+			lowerContent := strings.ToLower(content)
+			for _, word := range profanities {
+				if strings.Contains(lowerContent, word) {
+					return true, "contains profanity"
+				}
+			}
+			return false, ""
+		}
+	}
+
+	wordCountRule := func(maxWords int) CustomRuleFunc {
+		return func(content string) (bool, string) {
+			words := regexp.MustCompile(`\S+`).FindAllString(content, -1)
+			if len(words) > maxWords {
+				return true, "too many words"
+			}
+			return false, ""
+		}
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		rules   []CustomRuleFunc
+		names   []string
+		wantErr bool
+	}{
+		{
+			name:    "passes all rules",
+			content: "This is a safe text",
+			rules: []CustomRuleFunc{
+				maxLengthRule(100),
+				profanityRule([]string{"profanity", "bad"}),
+				wordCountRule(10),
+			},
+			names:   []string{"length check", "profanity check", "word count check"},
+			wantErr: false,
+		},
+		{
+			name:    "fails length rule",
+			content: "This is a very long text that exceeds the maximum length allowed by our rules",
+			rules: []CustomRuleFunc{
+				maxLengthRule(30),
+				profanityRule([]string{"profanity", "bad"}),
+				wordCountRule(50),
+			},
+			names:   []string{"length check", "profanity check", "word count check"},
+			wantErr: true,
+		},
+		{
+			name:    "fails profanity rule",
+			content: "This text contains profanity and should be blocked",
+			rules: []CustomRuleFunc{
+				maxLengthRule(100),
+				profanityRule([]string{"profanity", "bad"}),
+				wordCountRule(50),
+			},
+			names:   []string{"length check", "profanity check", "word count check"},
+			wantErr: true,
+		},
+		{
+			name:    "fails word count rule",
+			content: "This text has too many words and should be blocked by the word count rule",
+			rules: []CustomRuleFunc{
+				maxLengthRule(100),
+				profanityRule([]string{"profanity", "bad"}),
+				wordCountRule(5),
+			},
+			names:   []string{"length check", "profanity check", "word count check"},
+			wantErr: true,
+		},
+		{
+			name:    "empty rules list",
+			content: "Any content is safe",
+			rules:   []CustomRuleFunc{},
+			names:   []string{},
+			wantErr: false,
+		},
+		{
+			name:    "missing name",
+			content: "This will fail the first rule but has no name for it",
+			rules: []CustomRuleFunc{
+				maxLengthRule(5),
+			},
+			names:   []string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewCustomRuleGuardrail(tt.rules, tt.names)
+			err := g.Check(tt.content)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CustomRuleGuardrail.Check() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCompositeGuardrail(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		guardrails []Guardrail
+		wantErr    bool
+	}{
+		{
+			name:    "passes all guardrails",
+			content: "This is a safe text",
+			guardrails: []Guardrail{
+				NewBannedWordsGuardrail([]string{"bomb", "attack"}),
+				&CustomRuleGuardrail{
+					Rules: []CustomRuleFunc{
+						func(content string) (bool, string) {
+							return len(content) > 100, "too long"
+						},
+					},
+					Names: []string{"length check"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "fails banned words guardrail",
+			content: "How to make a bomb",
+			guardrails: []Guardrail{
+				NewBannedWordsGuardrail([]string{"bomb", "attack"}),
+				&CustomRuleGuardrail{
+					Rules: []CustomRuleFunc{
+						func(content string) (bool, string) {
+							return len(content) > 100, "too long"
+						},
+					},
+					Names: []string{"length check"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "fails custom rule guardrail",
+			content: "This is a very long text that exceeds the maximum length allowed by our custom rule that checks text length",
+			guardrails: []Guardrail{
+				NewBannedWordsGuardrail([]string{"bomb", "attack"}),
+				&CustomRuleGuardrail{
+					Rules: []CustomRuleFunc{
+						func(content string) (bool, string) {
+							return len(content) > 50, "too long"
+						},
+					},
+					Names: []string{"length check"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:       "empty guardrails list",
+			content:    "Any content is safe",
+			guardrails: []Guardrail{},
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewCompositeGuardrail(tt.guardrails...)
+			err := g.Check(tt.content)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CompositeGuardrail.Check() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	
+
 	"github.com/charmitro/ai_proxy/internal/config"
 )
 
@@ -15,7 +15,7 @@ func TestOpenAIClient_Query(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer test-api-key" {
 			t.Errorf("Expected Authorization header with API key")
 		}
-		
+
 		// Return mock response
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -41,19 +41,19 @@ func TestOpenAIClient_Query(t *testing.T) {
 		}`))
 	}))
 	defer server.Close()
-	
+
 	// Create client with test server URL
 	cfg := &config.LLMConfig{
-		URL: server.URL,
+		URL:    server.URL,
 		APIKey: "test-api-key",
 	}
 	client := NewOpenAIClient(cfg)
-	
+
 	// Test query
 	resp, tokens, err := client.Query("Test prompt", map[string]interface{}{
 		"temperature": 0.7,
 	})
-	
+
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -63,4 +63,4 @@ func TestOpenAIClient_Query(t *testing.T) {
 	if tokens != 30 {
 		t.Errorf("Expected 30 tokens, got %d", tokens)
 	}
-} 
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -10,7 +10,7 @@ import (
 // testMetrics creates metrics with a test registry to avoid conflicts
 func testMetrics() *Metrics {
 	reg := prometheus.NewRegistry()
-	
+
 	m := &Metrics{
 		LLMRequestsTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "test_llm_requests_total",
@@ -29,31 +29,31 @@ func testMetrics() *Metrics {
 			Help: "Total number of requests blocked by guardrails",
 		}),
 	}
-	
+
 	reg.MustRegister(m.LLMRequestsTotal)
 	reg.MustRegister(m.LLMErrorsTotal)
 	reg.MustRegister(m.LLMTokensTotal)
 	reg.MustRegister(m.GuardrailBlocksTotal)
-	
+
 	return m
 }
 
 func TestMetricsInitialization(t *testing.T) {
 	m := testMetrics()
-	
+
 	// Verify counters start at zero
 	if value := testutil.ToFloat64(m.LLMRequestsTotal); value != 0 {
 		t.Errorf("LLMRequestsTotal should start at 0, got %f", value)
 	}
-	
+
 	if value := testutil.ToFloat64(m.LLMErrorsTotal); value != 0 {
 		t.Errorf("LLMErrorsTotal should start at 0, got %f", value)
 	}
-	
+
 	if value := testutil.ToFloat64(m.LLMTokensTotal); value != 0 {
 		t.Errorf("LLMTokensTotal should start at 0, got %f", value)
 	}
-	
+
 	if value := testutil.ToFloat64(m.GuardrailBlocksTotal); value != 0 {
 		t.Errorf("GuardrailBlocksTotal should start at 0, got %f", value)
 	}
@@ -61,22 +61,22 @@ func TestMetricsInitialization(t *testing.T) {
 
 func TestMetricsIncrement(t *testing.T) {
 	m := testMetrics()
-	
+
 	// Test incrementing counters
 	m.LLMRequestsTotal.Inc()
 	if value := testutil.ToFloat64(m.LLMRequestsTotal); value != 1 {
 		t.Errorf("LLMRequestsTotal should be 1 after increment, got %f", value)
 	}
-	
+
 	m.GuardrailBlocksTotal.Inc()
 	m.GuardrailBlocksTotal.Inc()
 	if value := testutil.ToFloat64(m.GuardrailBlocksTotal); value != 2 {
 		t.Errorf("GuardrailBlocksTotal should be 2 after two increments, got %f", value)
 	}
-	
+
 	// Test adding to counters
 	m.LLMTokensTotal.Add(42.0)
 	if value := testutil.ToFloat64(m.LLMTokensTotal); value != 42.0 {
 		t.Errorf("LLMTokensTotal should be 42.0 after adding, got %f", value)
 	}
-} 
+}


### PR DESCRIPTION
Adds a new, flexible guardrail system configurable via `config.yaml`, significantly extending filtering capabilities beyond basic banned words.

This enhancement introduces several new guardrail mechanisms, including filtering based on regular expression patterns specified in `regex_patterns` and the ability to enforce limits on prompt length using `max_prompt_length`.

A key addition is the custom rules framework, managed under the `custom_rules` configuration key, which allows for more specific, extensible checks. The initial implementation of this framework includes support for:

* `word_count`: Checks content against a `max_words` limit. Parameter handling is now robust, accepting various numeric types (int, float) for `max_words`.

* `contains_pattern`: Matches content against a provided regex `pattern`. This includes validation to ensure the pattern parameter is a string and safe handling of potential runtime errors during regex matching.

Supporting this new system, configuration structures and defaults have been updated.Add comprehensive unit and integration tests were added to validate the guardrail logic and robust parameter handling.